### PR TITLE
Filterable no by default for attributes.

### DIFF
--- a/Model/Catalog/Product/Attribute/Creator/Strategy/AbstractStrategy.php
+++ b/Model/Catalog/Product/Attribute/Creator/Strategy/AbstractStrategy.php
@@ -54,7 +54,7 @@ abstract class  AbstractStrategy implements AttributeCreationStrategyInterface
         'required'                => false,
         'user_defined'            => true,
         'searchable'              => true,
-        'filterable'              => true,
+        'filterable'              => false,
         'comparable'              => true,
         'visible_on_front'        => true,
         'used_in_product_listing' => true,


### PR DESCRIPTION
Filterable should be set to no by default.
Cause only attribute types Yes/No, Dropdown, Multiple Select and Price are supported for filtering / layered navigation.